### PR TITLE
Update README file to use terraform 0.6.3.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,6 @@ Architecture
 
 This will create a bastion host and CloudFoundry install that is confined to one subnet, pulling external IPs from a second subnet.
 
-Upstream Terraform issues
--------------------------
-
-Terraform does not yet officially support Openstack. Development of this terraform repo was done using an experimental provider available at [jrperritt/terraform](https://github.com/jrperritt/terraform/tree/openstack-gophercloud-v1.0) using the openstack-gophercloud-v1.0 branch. Hopefully that work will be merged into master at some point, and we could use that.
-
-- [![hashicorp/terraform/issues/51](https://github-shields.com/github/hashicorp/terraform/issues/51.svg)](https://github-shields.com/github/hashicorp/terraform/issues/51) - the issue for having terraform natively support Openstack.
-
 Upstream Cloud Foundry issues
 -----------------------------
 
@@ -37,10 +30,10 @@ You **must** being using at least terraform version 0.4.0 with the openstack pro
 
 ```
 $ terraform -v
-Terraform v0.4.0
+Terraform v0.6.3
 ```
 
-You can install terraform 0.4.0+ via [https://www.terraform.io/downloads.html]
+You can install terraform 0.6.3+ via [https://www.terraform.io/downloads.html]
 
 Your chosen region must have sufficient quota to spin up **all** of the machines. While building various bits, the install process can use up to 13 VMs, settling down to use 7 machines long-term (more, if you want more runners).
 

--- a/README.md
+++ b/README.md
@@ -26,14 +26,14 @@ You must create a separate user just for this purpose, that does **not** have ad
 
 Unlike the AWS version of this, you do not need to upload your SSH key before starting. Note the path to the pem/private key files that you want to use and we will put them in the config file further down.
 
-You **must** being using at least terraform version 0.4.0 with the openstack provider compiled and in the same directory as your terraform binary.
+You **must** being using at least terraform version 0.6.3 with the openstack provider compiled and in the same directory as your terraform binary.
 
 ```
 $ terraform -v
 Terraform v0.6.3
 ```
 
-You can install terraform 0.6.3+ via [https://www.terraform.io/downloads.html]
+You can install terraform 0.6.3+ via [https://www.terraform.io/downloads.html] or using `brew` [package manager](http://brew.sh/) on Mac OS X.
 
 Your chosen region must have sufficient quota to spin up **all** of the machines. While building various bits, the install process can use up to 13 VMs, settling down to use 7 machines long-term (more, if you want more runners).
 

--- a/README.md
+++ b/README.md
@@ -112,8 +112,8 @@ Look in `variables.tf` to see all of the variables that can be set or overriden.
 ```
 network # The first two octets to use within the VPC, e.g. 10.0 or 192.168
 auth_url # The API of your Openstack instance to auth against, like http://10.2.95.100:5000/v2.0
-tenant_name # The name of the tenant to use - this must already be defined
-tenant_id # The ID of the tenant, might be the same as the tenant name
+tenant_name # The name of the tenant to use - this will be used to create names for your resources
+tenant_id # The ID of the tenant
 username # User to authenticate against the Openstack API
 password # Password for that user
 public_key_path # Literal path to public ssh key file on the computer running Terraform - /home/user/keys/example.pub

--- a/openstack-cf-install.tf
+++ b/openstack-cf-install.tf
@@ -1,6 +1,6 @@
 provider "openstack" {
   auth_url = "${var.auth_url}"
-  tenant_name = "${var.tenant_name}"
+  tenant_id = "${var.tenant_id}"
   user_name = "${var.username}"
   password = "${var.password}"
 }

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -1,7 +1,7 @@
 network = "192.168"
 auth_url="http://10.2.95.100:5000/v2.0"
 tenant_name="TENANT"
-tenant_id="MYTENANT"          # NOTE: tenant_id can be the same with tenant_name
+tenant_id="TENANT_ID"
 username="USER"
 password="PASS"
 public_key_path="/Users/myuser/.ssh/id_rsa.pub"

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -1,7 +1,7 @@
 network = "192.168"
 auth_url="http://10.2.95.100:5000/v2.0"
 tenant_name="TENANT"
-tenant_id="MYTENANT"
+tenant_id="MYTENANT"          # NOTE: tenant_id can be the same with tenant_name
 username="USER"
 password="PASS"
 public_key_path="/Users/myuser/.ssh/id_rsa.pub"
@@ -10,3 +10,4 @@ floating_ip_pool="net04_ext"
 region="RegionOne"
 network_external_id="xxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxx"
 ntp_servers="0.pool.ntp.org,1.pool.ntp.org"
+image_name="ubuntu-14.04"

--- a/variables.tf
+++ b/variables.tf
@@ -1,5 +1,4 @@
 variable "auth_url" {}
-variable "tenant_name" {}
 variable "tenant_id" {}
 variable "username" {}
 variable "password" {}
@@ -8,6 +7,11 @@ variable "public_key_path" {}
 variable "floating_ip_pool" {}
 variable "network_external_id" {}
 variable "ntp_servers" {}
+
+variable "tenant_name" {
+  default = "cf"
+}
+
 variable "region" {
   default = "RegionOne"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -7,6 +7,7 @@ variable "key_path" {}
 variable "public_key_path" {}
 variable "floating_ip_pool" {}
 variable "network_external_id" {}
+variable "ntp_servers" {}
 variable "region" {
   default = "RegionOne"
 }


### PR DESCRIPTION
Hey, all.

At this moment support of openstack provider is merged to terraform version 0.6.3 ([docs](https://terraform.io/docs/providers/openstack/index.html)).

The changes in newer version of terraform are compatible with the current version of `terraform-openstack-cf-install`, I've tried it out. Still I had some problems while I needed to re-run provisioning script, but they were not connected with terraform.
